### PR TITLE
Remove #path method from Object

### DIFF
--- a/lib/gedcom.rb
+++ b/lib/gedcom.rb
@@ -51,14 +51,9 @@
 #objects to_gedcom() method. This can occur at any level, from Transmission downward.
 #
 
-def path(s,fs='/')
-  last_fs = s.rindex(fs)
-  last_fs ? s[0..last_fs] : ""
+%w(gedcom parser chart).each do |dir|
+  $: << File.join(File.dirname(File.expand_path(__FILE__)), dir)
 end
-
-$: << "#{path(__FILE__)}gedcom"
-$: << "#{path(__FILE__)}parser"
-$: << "#{path(__FILE__)}chart"
 
 require 'gedcom_parser.rb'
 #require 'chart.rb'


### PR DESCRIPTION
Hi,

I had some trouble parsing a YAML file when running in JRuby. It turns out that Object responded to `#path`, which messed up the JRuby Psych parser. I tracked the problem down to the `path` method defined in this gem. You probably didn't intend for every object to now have a `path` method. =)

I fixed things up so there's no `path` method defined on Object now.

Thanks again for creating the gem!
